### PR TITLE
Add TOOLCHAIN_PREFIX option for 64/32-bit combo installations

### DIFF
--- a/firmware/blink/Makefile
+++ b/firmware/blink/Makefile
@@ -1,5 +1,11 @@
-TOOLCHAIN_PATH = /opt/riscv32imc/bin/
-# TOOLCHAIN_PATH = /ef/apps/bin/
+
+TOOLCHAIN_PATH=
+# TOOLCHAIN_PATH=/opt/riscv32imc/bin/
+# TOOLCHAIN_PATH=/ef/apps/bin/
+
+# Set the prefix for `riscvXX-unknown-elf-*`
+# On installations using `multilib`, this will be `riscv64` even for compiling to 32-bit targets
+TOOLCHAIN_PREFIX?=riscv32
 
 # ---- Test patterns for project raven ----
 
@@ -10,15 +16,15 @@ PATTERN = blink
 hex:  ${PATTERN:=.hex}
 
 %.elf: %.c ../sections.lds ../start.s
-	$(TOOLCHAIN_PATH)riscv32-unknown-elf-gcc -O0 -march=rv32i -Wl,-Bstatic,-T,../sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ ../start.s $<
-	${TOOLCHAIN_PATH}/riscv32-unknown-elf-objdump -D blink.elf > blink.lst
+	$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-unknown-elf-gcc -O0 -mabi=ilp32 -march=rv32i -Wl,-Bstatic,-T,../sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ ../start.s $<
+	${TOOLCHAIN_PATH}$(TOOLCHAIN_PREFIX)-unknown-elf-objdump -D blink.elf > blink.lst
 
 %.hex: %.elf
-	$(TOOLCHAIN_PATH)riscv32-unknown-elf-objcopy -O verilog $< $@
+	$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-unknown-elf-objcopy -O verilog $< $@
 	sed -i '.orig' -e 's/@10000000/@00000000/g' $@
 
 %.bin: %.elf
-	$(TOOLCHAIN_PATH)riscv32-unknown-elf-objcopy -O binary $< $@
+	$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-unknown-elf-objcopy -O binary $< $@
 
 client: client.c
 	gcc client.c -o client


### PR DESCRIPTION
This is the setup installed by MacOS's Homebrew for example.  
Details: 

* https://github.com/riscv-software-src/homebrew-riscv#supporting-32-bit-targets
* https://github.com/riscv-software-src/homebrew-riscv/issues/74

On my system a successful programming then requires: 

```
TOOLCHAIN_PREFIX=riscv64 make clean flash
```

Commit also adds the `-mabi=ilp32` option to ensure the compiler knows to target 32-bit `int`s, `long`s, and pointers. 