### PR TITLE
Remove space in SED_CMD edit in place suffix

### DIFF
--- a/firmware_vex/nucleo/Makefile
+++ b/firmware_vex/nucleo/Makefile
@@ -99,7 +99,7 @@ TOOLCHAIN_PATH=/usr/local/bin/
 TOOLCHAIN_PREFIX=riscv64-unknown-elf
 #TOOLCHAIN_PREFIX=riscv32-unknown-linux-gnu
 
-SED_CMD=sed -i '.orig' -e
+SED_CMD=sed -i'.orig' -e
 #SED_CMD=sed -ie
 
 .SUFFIXES:


### PR DESCRIPTION
No `.orig` backup file is generated with that space.