### PR TITLE
Fixing sed command

### DIFF
--- a/firmware_vex/gpio_test/Makefile
+++ b/firmware_vex/gpio_test/Makefile
@@ -1,7 +1,8 @@
 
 TOOLCHAIN_PATH=/usr/local/bin/
 #TOOLCHAIN_PATH=/opt/riscv32imc/bin/
-# TOOLCHAIN_PATH=/ef/apps/bin/
+#TOOLCHAIN_PATH=/ef/apps/bin/
+#TOOLCHAIN_PATH=/usr/bin/
 
 # Set the prefix for `riscvXX-unknown-elf-*`
 # On installations using `multilib`, this will be `riscv64` even for compiling to 32-bit targets
@@ -32,7 +33,7 @@ check: gpio_config_def.py gpio_config_io.py gpio_config_data.c
 
 %.hex: %.elf
 	$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-unknown-elf-objcopy -O verilog $< $@
-	sed -i '.orig' -e 's/@1000/@0000/g' $@
+	sed -i.orig -e 's/@1000/@0000/g' $@
 
 %.bin: %.elf
 	$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-unknown-elf-objcopy -O binary $< $@


### PR DESCRIPTION
On Ubuntu 21.10 sed needs the parameter for the -i to be attached directly without a space in between Adding additional TOOLCHAIN path