### PR TITLE
add jupyter notebooks

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,28 @@
+# silicon bring-up notebooks
+
+## Install
+
+```
+python3 -m venv env
+source env/bin/activate
+python -m pip install -r requirements.txt
+python -m mpy_kernel_upydevice.install
+```
+
+## Run jupyter
+
+```
+jupyter notebook
+```
+
+## Create a new notebook
+
+- Open `openmpw-bringup-template.ipynb` in Jupyter Notebook
+- Click *File > Make a Copy...*
+- Name the copy after your project, ex: `openmpw-bringup-mpw2-a5`
+
+## Bring up your chip
+
+- Run the cells of the notebooks
+- Add more cells to test specific aspect if your design
+- Send a pull request to https://github.com/efabless/caravel_board/ to share your notebooks with other OpenMPW participants.

--- a/notebooks/openmpw-bringup-template.ipynb
+++ b/notebooks/openmpw-bringup-template.ipynb
@@ -1,0 +1,712 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f48410c7",
+   "metadata": {},
+   "source": [
+    "# OpenMPW bringup notebook\n",
+    "\n",
+    "This goal of this notebook is to help you share a reproducible bringup methodology for your [OpenMPW](https://developers.google.com/silicon) project.\n",
+    "\n",
+    "- Cells without `%` [magic commands](https://ipython.readthedocs.io/en/stable/interactive/magics.html) run on the micropython board.\n",
+    "- Cells with the `%local` magic run on the host computer.\n",
+    "\n",
+    "This assumes that the board has already been flashed using the [installation](https://github.com/efabless/caravel_board/tree/main/firmware_vex/nucleo#installation) instructions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6067141d",
+   "metadata": {},
+   "source": [
+    "## Connect to the nucleo board"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "bddc042e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/dev/ttyACM0'"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%local\n",
+    "devices=!mpremote connect list | cut -d ' ' -f 1\n",
+    "NUCLEO_DEVICE=devices[0]\n",
+    "NUCLEO_DEVICE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "c9fac05b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m\n",
+      " ** Serial connected **\n",
+      "\n",
+      "\u001b[0m"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:micropython-upydevice:Device pyboard connected in /dev/ttyACM0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SerialDevice @ /dev/ttyACM0, Type: pyboard, Class: SerialDevice\n",
+      "Firmware: MicroPython v1.19.1-616-g5987130af-dirty on 2022-11-20; NUCLEO-F746ZG with STM32F746\n",
+      "STM32 STLink, Manufacturer: STMicroelectronics\n",
+      "(MAC: 2f:00:4d:00:02:50:46:56:32:38:36:20)\n",
+      "\n",
+      "MicroPython v1.19.1-616-g5987130af-dirty on 2022-11-20; NUCLEO-F746ZG with STM32F746\n",
+      "Type \"help()\" for more information.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%serialconnect /dev/ttyACM0\n",
+    "# update the device name to match the device detected"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b75c4ef3",
+   "metadata": {},
+   "source": [
+    "## Run the diagnostic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "ffd8814d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "part name: MPW2_A5_0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# update those variable to match the part under test\n",
+    "\n",
+    "SHUTTLE='MPW2'  # OpenMPW shuttle ID\n",
+    "SLOT='A5'       # project slot ID\n",
+    "DIE='0'         # actual die ID\n",
+    "\n",
+    "PART_NAME=f'{SHUTTLE}_{SLOT}_{DIE}'\n",
+    "print('part name:', PART_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "49f5bc4d-fa83-4ba1-9804-cd91f585710f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " \n",
+      "===================================================================\n",
+      "io_config -- version 1.2.0\n",
+      "voltage = 1.60, analog = False\n",
+      "===================================================================\n",
+      " \n",
+      "===================================================================\n",
+      "== Beginning IO configuration test.  Testing LOW IO chain...     ==\n",
+      "===================================================================\n",
+      " \n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[01] - H_INDEPENDENT >> Passed\n",
+      "gpio[02] - H_INDEPENDENT >> Failed\n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[01] - H_INDEPENDENT >> Passed\n",
+      "gpio[02] - H_DEPENDENT   >> Passed\n",
+      "gpio[03] - H_INDEPENDENT >> Passed\n",
+      "gpio[04] - H_INDEPENDENT >> Passed\n",
+      "gpio[05] - H_INDEPENDENT >> Passed\n",
+      "gpio[06] - H_INDEPENDENT >> Passed\n",
+      "gpio[07] - H_INDEPENDENT >> Passed\n",
+      "gpio[08] - H_INDEPENDENT >> Failed\n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[01] - H_INDEPENDENT >> Passed\n",
+      "gpio[02] - H_DEPENDENT   >> Passed\n",
+      "gpio[03] - H_INDEPENDENT >> Passed\n",
+      "gpio[04] - H_INDEPENDENT >> Passed\n",
+      "gpio[05] - H_INDEPENDENT >> Passed\n",
+      "gpio[06] - H_INDEPENDENT >> Passed\n",
+      "gpio[07] - H_INDEPENDENT >> Passed\n",
+      "gpio[08] - H_DEPENDENT   >> Passed\n",
+      "gpio[09] - H_INDEPENDENT >> Passed\n",
+      "gpio[10] - H_INDEPENDENT >> Failed\n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[01] - H_INDEPENDENT >> Passed\n",
+      "gpio[02] - H_DEPENDENT   >> Passed\n",
+      "gpio[03] - H_INDEPENDENT >> Passed\n",
+      "gpio[04] - H_INDEPENDENT >> Passed\n",
+      "gpio[05] - H_INDEPENDENT >> Passed\n",
+      "gpio[06] - H_INDEPENDENT >> Passed\n",
+      "gpio[07] - H_INDEPENDENT >> Passed\n",
+      "gpio[08] - H_DEPENDENT   >> Passed\n",
+      "gpio[09] - H_INDEPENDENT >> Passed\n",
+      "gpio[10] - H_DEPENDENT   >> Failed\n",
+      " \n",
+      "===================================================================\n",
+      "== LOW IO chain test complete.  Testing HIGH IO chain...         ==\n",
+      "===================================================================\n",
+      " \n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[36] - H_INDEPENDENT >> Failed\n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[36] - H_DEPENDENT   >> Passed\n",
+      "gpio[35] - H_INDEPENDENT >> Passed\n",
+      "gpio[34] - H_INDEPENDENT >> Passed\n",
+      "gpio[33] - H_INDEPENDENT >> Failed\n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[36] - H_DEPENDENT   >> Passed\n",
+      "gpio[35] - H_INDEPENDENT >> Passed\n",
+      "gpio[34] - H_INDEPENDENT >> Failed\n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[36] - H_DEPENDENT   >> Passed\n",
+      "gpio[35] - H_INDEPENDENT >> Passed\n",
+      "gpio[34] - H_DEPENDENT   >> Failed\n",
+      " \n",
+      "===================================================================\n",
+      "== HIGH IO chain test complete. IO configuration test complete.  ==\n",
+      "===================================================================\n",
+      " \n",
+      " \n",
+      "===================================================================\n",
+      "===================================================================\n",
+      "== LOW chain FAILED.   Valid IO = 0 thru 09.                      ==\n",
+      "== HIGH chain FAILED.  Valid IO = 35 thru 37.                    ==\n",
+      "===================================================================\n",
+      " \n",
+      "*** Run 'make get_config' to retrieve IO configure file (gpio_config_def.py)\n",
+      "\n",
+      " \n",
+      "             "
+     ]
+    }
+   ],
+   "source": [
+    "import io_config\n",
+    "\n",
+    "io_config.run(part_name=PART_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "88d9ba2a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "# gpio_config_def.py file for part A5_0\n",
+      "# io_config -- version 1.2.0\n",
+      "voltage = 1.60\n",
+      "analog = False\n",
+      "\n",
+      "H_NONE        = 0  \n",
+      "H_DEPENDENT   = 1  \n",
+      "H_INDEPENDENT = 2  \n",
+      "H_SPECIAL     = 3  \n",
+      "H_UNKNOWN     = 4  \n",
+      "\n",
+      "# voltage: 1.6\n",
+      "# configuration failed in gpio[10], anything after is invalid\n",
+      "gpio_l = [\n",
+      "['IO[0]', H_NONE],\n",
+      "['IO[1]', H_INDEPENDENT],\n",
+      "['IO[2]', H_DEPENDENT],\n",
+      "['IO[3]', H_INDEPENDENT],\n",
+      "['IO[4]', H_INDEPENDENT],\n",
+      "['IO[5]', H_INDEPENDENT],\n",
+      "['IO[6]', H_INDEPENDENT],\n",
+      "['IO[7]', H_INDEPENDENT],\n",
+      "['IO[8]', H_DEPENDENT],\n",
+      "['IO[9]', H_INDEPENDENT],\n",
+      "['IO[10]', H_UNKNOWN],\n",
+      "['IO[11]', H_UNKNOWN],\n",
+      "['IO[12]', H_UNKNOWN],\n",
+      "['IO[13]', H_UNKNOWN],\n",
+      "['IO[14]', H_UNKNOWN],\n",
+      "['IO[15]', H_UNKNOWN],\n",
+      "['IO[16]', H_UNKNOWN],\n",
+      "['IO[17]', H_UNKNOWN],\n",
+      "['IO[18]', H_UNKNOWN],\n",
+      "]\n",
+      "# voltage: 1.6\n",
+      "# configuration failed in gpio[34], anything before is invalid\n",
+      "gpio_h = [\n",
+      "['IO[37]', H_NONE],\n",
+      "['IO[36]', H_DEPENDENT],\n",
+      "['IO[35]', H_INDEPENDENT],\n",
+      "['IO[34]', H_UNKNOWN],\n",
+      "['IO[33]', H_UNKNOWN],\n",
+      "['IO[32]', H_UNKNOWN],\n",
+      "['IO[31]', H_UNKNOWN],\n",
+      "['IO[30]', H_UNKNOWN],\n",
+      "['IO[29]', H_UNKNOWN],\n",
+      "['IO[28]', H_UNKNOWN],\n",
+      "['IO[27]', H_UNKNOWN],\n",
+      "['IO[26]', H_UNKNOWN],\n",
+      "['IO[25]', H_UNKNOWN],\n",
+      "['IO[24]', H_UNKNOWN],\n",
+      "['IO[23]', H_UNKNOWN],\n",
+      "['IO[22]', H_UNKNOWN],\n",
+      "['IO[21]', H_UNKNOWN],\n",
+      "['IO[20]', H_UNKNOWN],\n",
+      "['IO[19]', H_UNKNOWN],\n",
+      "]\n",
+      "\n",
+      "\"# gpio_config_def.py file for part A5_0\\n# io_config -- version 1.2.0\\nvoltage = 1.60\\nanalog = False\\n\\nH_NONE        = 0  \\nH_DEPENDENT   = 1  \\nH_INDEPENDENT = 2  \\nH_SPECIAL     = 3  \\nH_UNKNOWN     = 4  \\n\\n# voltage: 1.6\\n# configuration failed in gpio[10], anything after is invalid\\ngpio_l = [\\n['IO[0]', H_NONE],\\n['IO[1]', H_INDEPENDENT],\\n['IO[2]', H_DEPENDENT],\\n['IO[3]', H_INDEPENDENT],\\n['IO[4]', H_INDEPENDENT],\\n['IO[5]', H_INDEPENDENT],\\n['IO[6]', H_INDEPENDENT],\\n['IO[7]', H_INDEPENDENT],\\n['IO[8]', H_DEPENDENT],\\n['IO[9]', H_INDEPENDENT],\\n['IO[10]', H_UNKNOWN],\\n['IO[11]', H_UNKNOWN],\\n['IO[12]', H_UNKNOWN],\\n['IO[13]', H_UNKNOWN],\\n['IO[14]', H_UNKNOWN],\\n['IO[15]', H_UNKNOWN],\\n['IO[16]', H_UNKNOWN],\\n['IO[17]', H_UNKNOWN],\\n['IO[18]', H_UNKNOWN],\\n]\\n# voltage: 1.6\\n# configuration failed in gpio[34], anything before is invalid\\ngpio_h = [\\n['IO[37]', H_NONE],\\n['IO[36]', H_DEPENDENT],\\n['IO[35]', H_INDEPENDENT],\\n['IO[34]', H_UNKNOWN],\\n['IO[33]', H_UNKNOWN],\\n['IO[32]', H_UNKNOWN],\\n['IO[31]', H_UNKNOWN],\\n['IO[30]', H_UNKNOWN],\\n['IO[29]', H_UNKNOWN],\\n['IO[28]', H_UNKNOWN],\\n['IO[27]', H_UNKNOWN],\\n['IO[26]', H_UNKNOWN],\\n['IO[25]', H_UNKNOWN],\\n['IO[24]', H_UNKNOWN],\\n['IO[23]', H_UNKNOWN],\\n['IO[22]', H_UNKNOWN],\\n['IO[21]', H_UNKNOWN],\\n['IO[20]', H_UNKNOWN],\\n['IO[19]', H_UNKNOWN],\\n]\\n\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "f = open('gpio_config_def.py')\n",
+    "GPIO_CONFIG = f.read()\n",
+    "print(GPIO_CONFIG)\n",
+    "GPIO_CONFIG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "798dc916",
+   "metadata": {},
+   "source": [
+    "## Run a sanity check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "64fd4ef1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " \n",
+      "===================================================================\n",
+      "io_config -- version 1.2.0\n",
+      "voltage = 1.60, analog = False\n",
+      "===================================================================\n",
+      "===================================================================\n",
+      "== Beginning SANITY for LOW IO chain...                          ==\n",
+      "===================================================================\n",
+      " \n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[01] - H_INDEPENDENT >> Passed\n",
+      "gpio[02] - H_INDEPENDENT >> Passed\n",
+      "gpio[03] - H_INDEPENDENT >> Passed\n",
+      "gpio[04] - H_INDEPENDENT >> Passed\n",
+      "gpio[05] - H_INDEPENDENT >> Passed\n",
+      "gpio[06] - H_INDEPENDENT >> Passed\n",
+      "gpio[07] - H_INDEPENDENT >> Passed\n",
+      "gpio[08] - H_INDEPENDENT >> Passed\n",
+      "gpio[09] - H_INDEPENDENT >> Passed\n",
+      "gpio[10] - H_INDEPENDENT >> Failed\n",
+      "**** SANITY CHECK FOR LOW CHAIN PASSED!!\n",
+      " \n",
+      "===================================================================\n",
+      "== LOW IO chain test complete.  Testing HIGH IO chain...         ==\n",
+      "===================================================================\n",
+      " \n",
+      "::::: flashing Caravel :::::\n",
+      "gpio[36] - H_INDEPENDENT >> Passed\n",
+      "gpio[35] - H_INDEPENDENT >> Passed\n",
+      "gpio[34] - H_INDEPENDENT >> Passed\n",
+      "gpio[33] - H_INDEPENDENT >> Failed\n",
+      "**** SANITY CHECK FOR HIGH CHAIN FAILED!!\n",
+      " \n",
+      "===================================================================\n",
+      "== HIGH IO chain test complete. SANITY test complete.            ==\n",
+      "===================================================================\n",
+      " \n",
+      " \n",
+      "===================================================================\n",
+      "== LOW chain PASSED.                                             ==\n",
+      "== HIGH chain FAILED.                                            ==\n",
+      "===================================================================\n",
+      " \n",
+      "             "
+     ]
+    }
+   ],
+   "source": [
+    "import io_config\n",
+    "\n",
+    "io_config.run_sanity_check()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efd3fba8",
+   "metadata": {},
+   "source": [
+    "## Run the GPIO test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "a4002f38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Welcome to rshell. Use Control-D (or the exit command) to exit rshell.\n",
+      "\n",
+      "No MicroPython boards connected - use the connect command to add one\n",
+      "\n",
+      "\u001b[1;32m/home/proppy/src/github.com/efabless/caravel_board/notebooks\u001b[0m> \n",
+      "\n",
+      "Using buffer-size of 32\n",
+      "Connecting to /dev/ttyACM0 (buffer-size 32)...\n",
+      "Trying to connect to REPL  connected\n",
+      "Retrieving sysname ... pyboard\n",
+      "Testing if ubinascii.unhexlify exists ... Y\n",
+      "Retrieving root directories ... /flash/\n",
+      "Setting time ... Feb 16, 2023 16:14:01\n",
+      "Evaluating board_name ... pyboard\n",
+      "Retrieving time epoch ... Jan 01, 2000\n",
+      "Copying '/flash/gpio_config_def.py' to '/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test/gpio_config_def.py' ...\n",
+      "make: Entering directory '/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test'\n",
+      "python3 ../gpio_config/gpio_config_builder.py\n",
+      "stream_h   = 111000000000111100000000011110000000001111000000000111100000000011110000000001111000000000111100000000011110000000001111000000000111100000000011110000000001111000000000111100000000011110000000001111000000000111100000000011100000000011100000000001\n",
+      "stream_l   = 000000111100000000111110000000011111000000001111100000000111110000000011111000000001111100000000111110000000011111000000001111100000000111100000000111100000000011100000000011100000000011100000000011100000000011100000000011100000000001100000000001\n",
+      "n_bits = 247\n",
+      "xpack-riscv-none-elf-gcc-11.3.0-1/bin/riscv-none-elf-gcc -I/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test -I../ -I../generated/ -O0 -mabi=ilp32 -march=rv32i -D__vexriscv__ -Wl,-Bstatic,-T,../sections.lds,--strip-debug -ffreestanding -nostdlib -o gpio_test.elf ../crt0_vex.S ../isr.c gpio_test.c\n",
+      "xpack-riscv-none-elf-gcc-11.3.0-1/bin/riscv-none-elf-objdump -D gpio_test.elf > gpio_test.lst\n",
+      "xpack-riscv-none-elf-gcc-11.3.0-1/bin/riscv-none-elf-objcopy -O verilog gpio_test.elf gpio_test.hex\n",
+      "sed -i.orig -e 's/@1000/@0000/g' gpio_test.hex\n",
+      "rm gpio_test.elf\n",
+      "make: Leaving directory '/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test'\n",
+      "Using buffer-size of 32\n",
+      "Connecting to /dev/ttyACM0 (buffer-size 32)...\n",
+      "Trying to connect to REPL  connected\n",
+      "Retrieving sysname ... pyboard\n",
+      "Testing if ubinascii.unhexlify exists ... Y\n",
+      "Retrieving root directories ... /flash/\n",
+      "Setting time ... Feb 16, 2023 16:14:02\n",
+      "Evaluating board_name ... pyboard\n",
+      "Retrieving time epoch ... Jan 01, 2000\n",
+      "Copying '/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test/gpio_test.hex' to '/flash/firmware.hex' ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "%local\n",
+    "!rshell -p {NUCLEO_DEVICE} cp /flash/gpio_config_def.py ../firmware_vex/gpio_test/\n",
+    "!make -C ../firmware_vex/gpio_test/ gpio_test.hex\n",
+    "!rshell -p {NUCLEO_DEVICE} cp ../firmware_vex/gpio_test/gpio_test.hex /flash/firmware.hex\n",
+    "!echo done"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "e3d9c597",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** flashing Caravel\n",
+      "status Good\n"
+     ]
+    }
+   ],
+   "source": [
+    "import io_config\n",
+    "\n",
+    "io_config.run_flash_caravel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb711fa3",
+   "metadata": {},
+   "source": [
+    "## Run your own firmware"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "34f563c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ../firmware_vex/gpio_test/gpio_config_io.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%local\n",
+    "%%writefile ../firmware_vex/gpio_test/gpio_config_io.py\n",
+    "# number of IO in the configuration stream for each chain\n",
+    "NUM_IO = 19\n",
+    "\n",
+    "# defines these values for IO configurations\n",
+    "C_MGMT_OUT = 0\n",
+    "C_MGMT_IN = 1\n",
+    "C_USER_BIDIR = 2\n",
+    "C_DISABLE = 3\n",
+    "C_ALL_ONES = 4\n",
+    "C_USER_BIDIR_WPU = 5\n",
+    "C_USER_BIDIR_WPD = 6\n",
+    "C_USER_IN_NOPULL = 7\n",
+    "C_USER_OUT = 8\n",
+    "\n",
+    "config_h = [\n",
+    "    C_MGMT_OUT,  #37\n",
+    "    C_MGMT_OUT,  #36\n",
+    "    C_MGMT_OUT,  #35\n",
+    "    C_DISABLE,  #34\n",
+    "    C_DISABLE,  #33\n",
+    "    C_DISABLE,  #32\n",
+    "    C_DISABLE,  #31\n",
+    "    C_DISABLE,  #30\n",
+    "    C_DISABLE,  #29\n",
+    "    C_DISABLE,  #28\n",
+    "    C_DISABLE,  #27\n",
+    "    C_DISABLE,  #26\n",
+    "    C_DISABLE,  #25\n",
+    "    C_DISABLE,  #24\n",
+    "    C_DISABLE,  #23\n",
+    "    C_DISABLE,  #22\n",
+    "    C_DISABLE,  #21\n",
+    "    C_DISABLE,  #20\n",
+    "    C_DISABLE,  #19\n",
+    "]\n",
+    "\n",
+    "del config_h[NUM_IO:]\n",
+    "\n",
+    "config_l = [\n",
+    "    C_DISABLE,   #0\n",
+    "    C_MGMT_OUT,   #1\n",
+    "    C_MGMT_OUT,   #2\n",
+    "    C_MGMT_OUT,   #3\n",
+    "    C_MGMT_OUT,   #4\n",
+    "    C_MGMT_OUT,   #5\n",
+    "    C_MGMT_OUT,   #6\n",
+    "    C_MGMT_OUT,   #7\n",
+    "    C_MGMT_OUT,   #8\n",
+    "    C_MGMT_OUT,   #9\n",
+    "    C_DISABLE,   #10\n",
+    "    C_DISABLE,   #11\n",
+    "    C_DISABLE,   #12\n",
+    "    C_DISABLE,   #13\n",
+    "    C_DISABLE,   #14\n",
+    "    C_DISABLE,   #15\n",
+    "    C_DISABLE,   #16\n",
+    "    C_DISABLE,   #17\n",
+    "    C_DISABLE,   #18\n",
+    "]\n",
+    "\n",
+    "del config_l[NUM_IO:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "acf94089",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ../firmware_vex/gpio_test/gpio_test.c\n"
+     ]
+    }
+   ],
+   "source": [
+    "%local\n",
+    "%%writefile ../firmware_vex/gpio_test/gpio_test.c\n",
+    "#include \"../defs.h\"\n",
+    "#include \"../gpio_config/gpio_config_io.c\"\n",
+    "\n",
+    "void set_registers() {\n",
+    "    reg_mprj_io_1 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_2 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_3 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_4 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_5 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_6 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_7 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_8 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_9 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_35 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_36 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "    reg_mprj_io_37 = GPIO_MODE_MGMT_STD_OUTPUT;\n",
+    "}\n",
+    "\n",
+    "void main()\n",
+    "{\n",
+    "    reg_gpio_mode1 = 1;\n",
+    "    reg_gpio_mode0 = 0;\n",
+    "    reg_gpio_ien = 1;\n",
+    "    reg_gpio_oe = 1;\n",
+    "\n",
+    "    set_registers();\n",
+    "    reg_mprj_datah = 0;\n",
+    "    reg_mprj_datal = 0;\n",
+    "    gpio_config_io();\n",
+    "\n",
+    "    reg_gpio_out = 1; // OFF\n",
+    "\n",
+    "    while(1) {\n",
+    "        // blink slowly\n",
+    "\n",
+    "        reg_mprj_datal = 0x00000000;\n",
+    "        reg_mprj_datah = 0x00000000;\n",
+    "\n",
+    "        reg_gpio_out = 0x0;\n",
+    "\n",
+    "        delay(5000000);\n",
+    "\n",
+    "        reg_mprj_datal = 0xffffffff;\n",
+    "        reg_mprj_datah = 0xffffffff;\n",
+    "\n",
+    "        reg_gpio_out = 0x1;\n",
+    "\n",
+    "        delay(5000000);\n",
+    "\n",
+    "    }\n",
+    "\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "1e3ebd5d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "make: Entering directory '/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test'\n",
+      "python3 ../gpio_config/gpio_config_builder.py\n",
+      "stream_h   = 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011100000000011100000000011100000000001\n",
+      "stream_l   = 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000111100000000111100000000111100000000011100000000011100000000011100000000011100000000011100000000011100000000000000000000000\n",
+      "n_bits = 247\n",
+      "xpack-riscv-none-elf-gcc-11.3.0-1/bin/riscv-none-elf-gcc -I/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test -I../ -I../generated/ -O0 -mabi=ilp32 -march=rv32i -D__vexriscv__ -Wl,-Bstatic,-T,../sections.lds,--strip-debug -ffreestanding -nostdlib -o gpio_test.elf ../crt0_vex.S ../isr.c gpio_test.c\n",
+      "xpack-riscv-none-elf-gcc-11.3.0-1/bin/riscv-none-elf-objdump -D gpio_test.elf > gpio_test.lst\n",
+      "xpack-riscv-none-elf-gcc-11.3.0-1/bin/riscv-none-elf-objcopy -O verilog gpio_test.elf gpio_test.hex\n",
+      "sed -i.orig -e 's/@1000/@0000/g' gpio_test.hex\n",
+      "rm gpio_test.elf\n",
+      "make: Leaving directory '/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test'\n",
+      "Using buffer-size of 32\n",
+      "Connecting to /dev/ttyACM0 (buffer-size 32)...\n",
+      "Trying to connect to REPL  connected\n",
+      "Retrieving sysname ... pyboard\n",
+      "Testing if ubinascii.unhexlify exists ... Y\n",
+      "Retrieving root directories ... /flash/\n",
+      "Setting time ... Feb 16, 2023 17:07:24\n",
+      "Evaluating board_name ... pyboard\n",
+      "Retrieving time epoch ... Jan 01, 2000\n",
+      "Copying '/home/proppy/src/github.com/efabless/caravel_board/firmware_vex/gpio_test/gpio_test.hex' to '/flash/firmware.hex' ...\n",
+      "done\n"
+     ]
+    }
+   ],
+   "source": [
+    "%local\n",
+    "!make -C ../firmware_vex/gpio_test/ gpio_test.hex\n",
+    "!rshell -p {NUCLEO_DEVICE} cp ../firmware_vex/gpio_test/gpio_test.hex /flash/firmware.hex\n",
+    "!echo done"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "5a981953",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** flashing Caravel\n",
+      "status Good\n"
+     ]
+    }
+   ],
+   "source": [
+    "import io_config\n",
+    "\n",
+    "io_config.run_flash_caravel()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "MicroPython upydevice kernel",
+   "language": "python",
+   "name": "micropython-upydevice"
+  },
+  "language_info": {
+   "codemirror_mode": "python",
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "pygments_lexer": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,0 +1,6 @@
+jupyterlab
+jupyter-micropython-upydevice
+mpremote
+mpy-cross
+rshell
+


### PR DESCRIPTION
This can be useful for the community to document their bring up experience.

This run jupyter with https://github.com/Carglglz/jupyter_upydevice_kernel allowing cells to run both on the host and the nucleoboard.

See an example here:
https://github.com/efabless/caravel_board/blob/870f32eafed8fbdc13a724e5616f8fe75d14185a/notebooks/openmpw-bringup-template.ipynb

- add notebooks template
- add documentaton to run jupyter 
- add requirements