### PR TITLE
Improve flasher script compatibility

### DIFF
--- a/gf180/util/caravel_hkflash.py
+++ b/gf180/util/caravel_hkflash.py
@@ -218,8 +218,12 @@ with open(file_path, mode='r') as f:
     x = f.readline()
     while x != '':
         if x[0] == '@':
-            addr = int(x[1:],16)
+            xparts = x[1:].split(' ', 1)
+            addr = int(xparts[0],16)
             print('setting address to {}'.format(hex(addr)))
+            if len(xparts) > 1:
+                x = xparts[1]
+                continue
         else:
             # print(x)
             values = bytearray.fromhex(x[0:len(x)-1])
@@ -298,8 +302,12 @@ with open(file_path, mode='r') as f:
     x = f.readline()
     while x != '':
         if x[0] == '@':
-            addr = int(x[1:],16)
+            xparts = x[1:].split(' ', 1)
+            addr = int(xparts[0],16)
             print('setting address to {}'.format(hex(addr)))
+            if len(xparts) > 1:
+                x = xparts[1]
+                continue
         else:
             # print(x)
             values = bytearray.fromhex(x[0:len(x)-1])


### PR DESCRIPTION
Adds support for hex files generated by [bincopy](https://pypi.org/project/bincopy/) with `verilog_vmem` output format.

The output of the `bincopy` python package includes the address at the beginning of each line, e.g.:

```
@00000000 B7 00 00 10 67 80 80 00 73 50 40 30 73 50 40 34 93 00 00 00 13 01 00 00 93 01 00 00 13 02 00 00
@00000020 93 02 00 00 13 03 00 00 93 03 00 00 13 04 00 00 93 04 00 00 93 06 00 00 13 07 00 00 93 07 00 00
@00000040 13 08 00 00 93 08 00 00 13 09 00 00 93 09 00 00 13 0A 00 00 93 0A 00 00 13 0B 00 00 93 0B 00 00
```

The parser currently fails on this input. This PR improves the parser so it will handle the above input correctly.