### PR TITLE
fix typo in binary reversal of project id

### DIFF
--- a/firmware/chipignite/util/caravel_hkdebug.py
+++ b/firmware/chipignite/util/caravel_hkdebug.py
@@ -123,7 +123,7 @@ product = slave.exchange([CARAVEL_REG_READ, 0x03], 1)
 print("   product    = {:02x}".format(int.from_bytes(product, byteorder='big')))
 
 data = slave.exchange([CARAVEL_STREAM_READ, 0x04], 4)
-print("   project ID = {:08x}".format(int('{0:32b}'.format(int.from_bytes(data, byteorder='big'))[::-1], 2)))
+print("   project ID = {:08x}".format(int('{:032b}'.format(int.from_bytes(data, byteorder='big'))[::-1], 2)))
 # print("   project ID = {:08x}".format(int.from_bytes(data, byteorder='big')))
 
 if int.from_bytes(mfg, byteorder='big') != 0x0456:
@@ -162,7 +162,7 @@ while (k != 'q'):
 
     elif k == '2':
             data = slave.exchange([CARAVEL_STREAM_READ, 0x04], 4)
-            print("Project ID = {:08x}".format(int('{0:32b}'.format(int.from_bytes(data, byteorder='big'))[::-1], 2)))
+            print("Project ID = {:08x}".format(int('{:032b}'.format(int.from_bytes(data, byteorder='big'))[::-1], 2)))
 
     elif k == '3':
         # reset CARAVEL

--- a/firmware/chipignite/util/caravel_projectid.py
+++ b/firmware/chipignite/util/caravel_projectid.py
@@ -123,7 +123,7 @@ product = slave.exchange([CARAVEL_REG_READ, 0x03], 1)
 print("   product    = {:02x}".format(int.from_bytes(product, byteorder='big')))
 
 data = slave.exchange([CARAVEL_STREAM_READ, 0x04], 4)
-print("   project ID = {:08x}".format(int('{0:32b}'.format(int.from_bytes(data, byteorder='big'))[::-1], 2)))
+print("   project ID = {:08x}".format(int('{:032b}'.format(int.from_bytes(data, byteorder='big'))[::-1], 2)))
 # print("   project ID = {:08x}".format(int.from_bytes(data, byteorder='big')))
 
 if int.from_bytes(mfg, byteorder='big') != 0x0456:


### PR DESCRIPTION
The formatting code left-pads with spaces instead of zeros, which gives the wrong results for even project IDs (i.e. those that start with a 0 when read in reverse from caravel).

E.g.
data == b'\x24\x36\xe0\x00'
int.from_bytes(data, byteorder='big') == 607576064
'{0:32b}'.format(int.from_bytes(data, byteorder='big')) == '  100100001101101110000000000000'
'{0:32b}'.format(int.from_bytes(data, byteorder='big'))[::-1] == '000000000000011101101100001001  '
"{:08x}".format(int('{0:32b}'.format(int.from_bytes(data, byteorder='big'))[::-1], 2)) == '0001db09'

Corrected version:
'{:032b}'.format(int.from_bytes(data, byteorder='big')) == '00100100001101101110000000000000'
'{:032b}'.format(int.from_bytes(data, byteorder='big'))[::-1] == '00000000000001110110110000100100'
"{:08x}".format(int('{:032b}'.format(int.from_bytes(data, byteorder='big'))[::-1], 2)) == '00076c24'